### PR TITLE
All post type archives

### DIFF
--- a/post-type-archive-links.php
+++ b/post-type-archive-links.php
@@ -159,13 +159,36 @@ class Post_Type_Archive_Links {
 		global $nav_menu_selected_id;
 
 		// Get post types
-		$post_types = get_post_types(
+		// Get custom visible custom post types
+		$custom_post_types = get_post_types(
 			array(
-				'public'   => true,
-				'_builtin' => false
+				'public'=>true,
+				'_builtin'=>false
 			),
 			'object'
 		);
+		// Get hidden custom post types 
+		$custom_hidden_post_types = get_post_types(
+			array(
+				'public'=>false,
+				'_builtin'=>false
+			),
+			'object'
+		);
+		// Get builtin post types
+		$builtin_post_types = get_post_types(
+			array(
+				'public'=>true,
+				'_builtin'=>true
+			),
+			'object'
+		);
+		// Merge all of the above in to one Object
+		$post_types = (object) array_merge(
+			(array) $custom_post_types, 
+			(array) $custom_hidden_post_types, 
+			(array) $builtin_post_types
+			);
 
 		$html = '<ul id="'. $this->metabox_list_id .'">';
 		foreach ( $post_types as $pt ) {


### PR DESCRIPTION
Usefull in somecases to create hierarchy in wordpress navigation and the menu hightlighting that comes with it. I was working on a project where a custom navigation was needed, but without the plugin (and the changes I've made) it was impossible to get proper menu highlighting and easy to manage navigational items.

I've used this plugin with the changes to set my defaults posts as a child to my "Blog"-page so that propper menu hightlighting is used ('.current-menu-parent, .current-menu-ancestor'). The same goes for custom post type archives where the menu highlighting was lacking when just using a custom navigation link (as in a direct URL to the archives).

_The changes were needed to get the above mentioned results. It might be an idea to make these changes optional for someone with Admin rights to turn them on or off._

_P.S.: I've previously request a pull on your other account's fork, my bad._
