### PR TITLE
Fix plugin compatibility with PHP 5.3

### DIFF
--- a/post-type-archive-links.php
+++ b/post-type-archive-links.php
@@ -358,8 +358,7 @@ class Post_Type_Archive_Links {
 					'filter' => FILTER_SANITIZE_STRING,
 					'flags' => FILTER_REQUIRE_ARRAY
 				)
-			),
-			true
+			)
 		);
 		empty( $post_types['post_types'] ) AND exit;
 		// return post types if chosen


### PR DESCRIPTION
The third parameter for `filter_input_array` was added in PHP 5.4.

It defaults to `true` so I just removed it.