### PR TITLE
Fix Warning in PHP < 5.4

### DIFF
--- a/post-type-archive-links.php
+++ b/post-type-archive-links.php
@@ -350,17 +350,34 @@ class Post_Type_Archive_Links {
 		// Nonce check
 		check_ajax_referer( self::NONCE, 'nonce' );
 
-		// Is a post type chosen?
-		$post_types = filter_input_array(
-			INPUT_POST,
-			array(
-				'post_types' => array(
-					'filter' => FILTER_SANITIZE_STRING,
-					'flags' => FILTER_REQUIRE_ARRAY
+		if(version_compare(PHP_VERSION, '4.5.0') >= 0) {
+
+			// Is a post type chosen?
+			$post_types = filter_input_array(
+				INPUT_POST,
+				array(
+					'post_types' => array(
+						'filter' => FILTER_SANITIZE_STRING,
+						'flags' => FILTER_REQUIRE_ARRAY
+					)
+				),
+				true
+			);
+
+		} else {
+
+			$post_types = filter_input_array(
+				INPUT_POST,
+				array(
+					'post_types' => array(
+						'filter' => FILTER_SANITIZE_STRING,
+						'flags' => FILTER_REQUIRE_ARRAY
+					)
 				)
-			),
-			true
-		);
+			);
+
+		}
+		
 		empty( $post_types['post_types'] ) AND exit;
 		// return post types if chosen
 		return array_values( $post_types['post_types'] );

--- a/post-type-archive-links.php
+++ b/post-type-archive-links.php
@@ -350,33 +350,16 @@ class Post_Type_Archive_Links {
 		// Nonce check
 		check_ajax_referer( self::NONCE, 'nonce' );
 
-		if(version_compare(PHP_VERSION, '5.4.0') >= 0) {
-
-			// Is a post type chosen?
-			$post_types = filter_input_array(
-				INPUT_POST,
-				array(
-					'post_types' => array(
-						'filter' => FILTER_SANITIZE_STRING,
-						'flags' => FILTER_REQUIRE_ARRAY
-					)
-				),
-				true
-			);
-
-		} else {
-
-			$post_types = filter_input_array(
-				INPUT_POST,
-				array(
-					'post_types' => array(
-						'filter' => FILTER_SANITIZE_STRING,
-						'flags' => FILTER_REQUIRE_ARRAY
-					)
+		// Is a post type chosen?
+		$post_types = filter_input_array(
+			INPUT_POST,
+			array(
+				'post_types' => array(
+					'filter' => FILTER_SANITIZE_STRING,
+					'flags' => FILTER_REQUIRE_ARRAY
 				)
-			);
-
-		}
+			)
+		);
 		
 		empty( $post_types['post_types'] ) AND exit;
 		// return post types if chosen

--- a/post-type-archive-links.php
+++ b/post-type-archive-links.php
@@ -350,7 +350,7 @@ class Post_Type_Archive_Links {
 		// Nonce check
 		check_ajax_referer( self::NONCE, 'nonce' );
 
-		if(version_compare(PHP_VERSION, '4.5.0') >= 0) {
+		if(version_compare(PHP_VERSION, '5.4.0') >= 0) {
 
 			// Is a post type chosen?
 			$post_types = filter_input_array(


### PR DESCRIPTION
For PHP versions < 5.4, `filter_input_array()` has two parameters, not three (see http://php.net/manual/en/function.filter-input-array.php).
Change adds a check for the PHP version and will not include the third argument if the version does not support it.
The error occurs when you attempt to add a post type archive to a menu. Instead, it yields an error and does not update the menu with the archive menu item:

    Warning: filter_input_array() expects at most 2 parameters, 3 given in /[...]/plugins/post-type-archive-links/post-type-archive-links.php on line 363.

Props to Lee Sandwith for discovery.